### PR TITLE
Refactor: 페이지 로드 시 전체 사원 목록이 조회되도록 수정

### DIFF
--- a/inflow/src/views/emp-search/EmployeeSearchView.vue
+++ b/inflow/src/views/emp-search/EmployeeSearchView.vue
@@ -53,10 +53,21 @@ import EmployeeDetail from '@/components/employee-search/EmployeeDetail.vue';
 
 import apiClient from '@/api/axios';
 
+// 0. 페이지 로드되자마자 모든 사원 목록 로드되도록
+const employees = ref([]);
+onMounted(async () => {
+  try{
+    const response = await apiClient.get('/departments/search/all-members');
+    employees.value = response.data.content;
+    console.log("응답 받은 모든 사원 목록:", employees.value);
+  } catch(error){
+    console.error('전체 사원 목록을 불러오지 못했습니다.', error);
+  }
+})
+
 
 // 1. 검색창 사원 목록 조회
 // search-bar 컴포넌트에서 받아온 정보 emloyees에 저장
-const employees = ref([]);
 // 검색어 처리 함수
 const handleSearch = async(query) => {
   try{


### PR DESCRIPTION
---
name: 기능 개발 이슈
assignees: ''

---

## 무슨 이유로 코드를 개발했는가
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트

## 관련 스크린 샷 
<img width="1728" alt="스크린샷 2024-12-01 오후 4 15 48" src="https://github.com/user-attachments/assets/590c57b1-0040-46fc-a002-0a93469a6e6a">


## 소스코드1
```javascript
// 0. 페이지 로드되자마자 모든 사원 목록 로드되도록
const employees = ref([]);
onMounted(async () => {
  try{
    const response = await apiClient.get('/departments/search/all-members');
    employees.value = response.data.content;
    console.log("응답 받은 모든 사원 목록:", employees.value);
  } catch(error){
    console.error('전체 사원 목록을 불러오지 못했습니다.', error);
  }
})


```


## 닫은 이슈(기능)
close #64
